### PR TITLE
Add test automation: PHPUnit suite + CI

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -59,4 +59,4 @@ jobs:
             - uses: 'ramsey/composer-install@v3'
               with:
                   composer-options: '--ignore-platform-req=ext-mongodb'
-            - run: './vendor/bin/php-cs-fixer fix --dry-run --diff'
+            - run: './vendor/bin/php-cs-fixer check --diff'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: "Static Analysis"
+name: "Tests"
 
 on:
     pull_request:
@@ -10,24 +10,10 @@ on:
 
 jobs:
 
-    syntax-linting:
+    tests:
         runs-on: 'ubuntu-24.04'
         strategy:
-            matrix:
-                php:
-                    - '8.2'
-                    - '8.3'
-                    - '8.4'
-        steps:
-            - uses: 'actions/checkout@v4'
-            - uses: 'shivammathur/setup-php@v2'
-              with:
-                  php-version: '${{ matrix.php }}'
-            - run: 'find src/ -type f -name "*.php" -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )'
-
-    phpstan:
-        runs-on: 'ubuntu-24.04'
-        strategy:
+            fail-fast: false
             matrix:
                 php:
                     - '8.2'
@@ -41,22 +27,28 @@ jobs:
             - uses: 'shivammathur/setup-php@v2'
               with:
                   php-version: '${{ matrix.php }}'
+                  extensions: 'pdo_sqlite'
+                  coverage: 'none'
             - uses: 'ramsey/composer-install@v3'
               with:
                   dependency-versions: '${{ matrix.dependency-versions }}'
-            - run: './vendor/bin/phpstan analyze --no-progress --error-format="github"'
+                  # MongoDB/ODM is out of scope; the suite never instantiates Mongo
+                  # objects, so the test pipeline must not depend on ext-mongodb.
+                  composer-options: '--ignore-platform-req=ext-mongodb'
+            - run: './vendor/bin/phpunit'
 
-    coding-standards:
+    coverage:
         runs-on: 'ubuntu-24.04'
         steps:
             - uses: 'actions/checkout@v4'
             - uses: 'shivammathur/setup-php@v2'
               with:
-                  # Pinned to the project's minimum PHP: the mb_str_functions rule
-                  # would rewrite trim()/ltrim() to mb_trim()/mb_ltrim() on PHP 8.4+
-                  # (where those functions exist), which do not exist on PHP 8.2/8.3.
-                  php-version: '8.2'
+                  php-version: '8.3'
+                  extensions: 'pdo_sqlite'
+                  coverage: 'pcov'
             - uses: 'ramsey/composer-install@v3'
               with:
+                  dependency-versions: 'highest'
                   composer-options: '--ignore-platform-req=ext-mongodb'
-            - run: './vendor/bin/php-cs-fixer fix --dry-run --diff'
+            - run: './vendor/bin/phpunit --coverage-clover coverage.xml'
+            - run: 'php tools/coverage-gate.php coverage.xml 95'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/docs/superpowers/
 /vendor/
 /composer.lock
 /.php-cs-fixer.cache
+/.phpunit.cache/
+/coverage.xml

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,6 +5,7 @@ $finder = (new PhpCsFixer\Finder())
     ->name('*.php')
     ->in([
         __DIR__ . '/src',
+        __DIR__ . '/tests',
     ])
     ->ignoreVCS(true);
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "doctrine/mongodb-odm": "^2.16",
         "friendsofphp/php-cs-fixer": "^3.95",
         "phpstan/phpstan": "^2.1",
-        "phpstan/phpstan-deprecation-rules": "^2.0"
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpunit/phpunit": "^11.5"
     },
     "suggest": {
         "doctrine/orm": "To store audit logs as entities in a relational database",
@@ -38,5 +39,13 @@
         "preferred-install": {
             "*": "dist"
         }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "coverage": [
+            "@putenv XDEBUG_MODE=coverage",
+            "phpunit --coverage-clover coverage.xml",
+            "@php tools/coverage-gate.php coverage.xml 95"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "friendsofphp/php-cs-fixer": "^3.95",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpunit/phpunit": "^11.5"
+        "phpunit/phpunit": "^11.5",
+        "symfony/cache": "^7.0 || ^8.0"
     },
     "suggest": {
         "doctrine/orm": "To store audit logs as entities in a relational database",

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
             "WeDevelop\\Audit\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "WeDevelop\\Audit\\Tests\\": "tests/"
+        }
+    },
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/Fixtures/Audit/ConcreteAuditEntity.php
+++ b/tests/Fixtures/Audit/ConcreteAuditEntity.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Audit;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+use WeDevelop\Audit\AuditLogInterface;
+use WeDevelop\Audit\Entity\AbstractAuditEntity;
+use WeDevelop\Audit\Entity\Subject;
+use WeDevelop\Audit\Enum\AuditSource;
+
+/**
+ * Concrete audit entity for tests, mirroring the userland entity from the
+ * tutorial: adds the identifier and the user/impersonatedBy associations that
+ * AbstractAuditEntity leaves to the implementor.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'audit_log')]
+class ConcreteAuditEntity extends AbstractAuditEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    private int $id;
+    private ?UserInterface $user = null;
+    private ?UserInterface $impersonatedBy = null;
+
+    /**
+     * Test-only flexible factory. Userland code constructs entities through
+     * fromAuditLog(); tests need to set arbitrary column values (e.g. an unknown
+     * action class, or a specific createdAt for ordering assertions).
+     *
+     * @param class-string<AuditLogInterface>|string $action
+     * @param array<string, mixed>|null $data
+     */
+    public static function create(
+        int $id,
+        string $action,
+        AuditSource $source,
+        \DateTimeImmutable $createdAt,
+        ?Subject $subject = null,
+        ?string $subjectClass = null,
+        ?string $subjectIdentifier = null,
+        ?array $data = null,
+        ?string $ipAddress = null,
+        ?UserInterface $user = null,
+        ?UserInterface $impersonatedBy = null,
+    ): self {
+        $entity = new self();
+        $entity->id = $id;
+        $entity->action = $action;
+        $entity->source = $source;
+        $entity->createdAt = $createdAt;
+        $entity->subject = $subject;
+        $entity->subjectClass = $subjectClass;
+        $entity->subjectIdentifier = $subjectIdentifier;
+        $entity->data = $data;
+        $entity->ipAddress = $ipAddress;
+        $entity->user = $user;
+        $entity->impersonatedBy = $impersonatedBy;
+
+        return $entity;
+    }
+
+    public static function fromAuditLog(AuditLogInterface $auditLog): self
+    {
+        $context = $auditLog->getContext();
+        $token = $context->token;
+        $subject = $auditLog->getSubject();
+
+        return self::create(
+            id: 0,
+            action: $auditLog::class,
+            source: $context->source,
+            createdAt: $auditLog->getLoggedAt(),
+            subject: $subject,
+            subjectClass: $subject?->class,
+            subjectIdentifier: $subject?->identifier,
+            data: $auditLog->getData(),
+            ipAddress: $context->ip?->address,
+            user: $token?->getUser(),
+            impersonatedBy: $token instanceof SwitchUserToken
+                ? $token->getOriginalToken()->getUser()
+                : null,
+        );
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): ?UserInterface
+    {
+        return $this->user;
+    }
+
+    public function getImpersonatedBy(): ?UserInterface
+    {
+        return $this->impersonatedBy;
+    }
+}

--- a/tests/Fixtures/Audit/ConcreteAuditLog.php
+++ b/tests/Fixtures/Audit/ConcreteAuditLog.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Audit;
+
+use WeDevelop\Audit\AbstractAuditLog;
+use WeDevelop\Audit\Entity\AuditEntityInterface;
+use WeDevelop\Audit\Entity\Subject;
+use WeDevelop\Audit\ValueObject\Context;
+
+/**
+ * Concrete audit log for tests, exercising AbstractAuditLog's shared behaviour.
+ */
+final readonly class ConcreteAuditLog extends AbstractAuditLog
+{
+    /** @param array<string, mixed>|null $data */
+    public static function create(
+        Context $context,
+        ?Subject $subject,
+        \DateTimeImmutable $loggedAt,
+        ?array $data,
+    ): self {
+        return new self($context, $subject, $loggedAt, $data);
+    }
+
+    public function createEntity(): AuditEntityInterface
+    {
+        return ConcreteAuditEntity::fromAuditLog($this);
+    }
+
+    public function getMessage(): string
+    {
+        return 'user.mfa.enabled';
+    }
+
+    /** @return array<string, string> */
+    public function getParameters(): array
+    {
+        return ['user' => 'alice'];
+    }
+
+    /**
+     * Two string-keyed entries: a string value (yielded as-is by getInfo()) and
+     * an array value (rendered as a TranslatableMessage by getInfo()).
+     *
+     * @return iterable<string, string|array<string, string>>
+     */
+    protected function defineAdditionalInfo(): iterable
+    {
+        yield 'summary' => 'user.mfa.enabled.summary';
+        yield 'method' => ['name' => 'totp'];
+    }
+}

--- a/tests/Fixtures/Doctrine/CompositeIdEntity.php
+++ b/tests/Fixtures/Doctrine/CompositeIdEntity.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Doctrine;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Mapped entity with a composite identifier (two `#[ORM\Id]` properties).
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'composite_id_entity')]
+class CompositeIdEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    private int $first;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'string')]
+    private string $second;
+
+    public function __construct(int $first, string $second)
+    {
+        $this->first = $first;
+        $this->second = $second;
+    }
+
+    public function getFirst(): int
+    {
+        return $this->first;
+    }
+
+    public function getSecond(): string
+    {
+        return $this->second;
+    }
+}

--- a/tests/Fixtures/Doctrine/IntegrationEntity.php
+++ b/tests/Fixtures/Doctrine/IntegrationEntity.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Doctrine;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A minimal mapped entity used by the integration tests (and reused by unit
+ * tests that need a single `#[ORM\Id]` property). The id is assigned, not
+ * generated, so tests control it directly.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'integration_entity')]
+class IntegrationEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    private int $id;
+
+    #[ORM\Column(type: 'string')]
+    private string $name;
+
+    public function __construct(int $id, string $name = 'fixture')
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Fixtures/Doctrine/UserEntity.php
+++ b/tests/Fixtures/Doctrine/UserEntity.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Doctrine;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * A mapped entity that is also a Symfony user, for exercising Context::refDb().
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'user_entity')]
+class UserEntity implements UserInterface
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    private int $id;
+
+    #[ORM\Column(type: 'string')]
+    private string $username;
+
+    public function __construct(int $id, string $username = 'alice')
+    {
+        $this->id = $id;
+        $this->username = $username;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /** @return list<string> */
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+}

--- a/tests/Fixtures/Doctrine/UserEntity.php
+++ b/tests/Fixtures/Doctrine/UserEntity.php
@@ -40,4 +40,7 @@ class UserEntity implements UserInterface
     {
         return $this->username;
     }
+
+    // Required by Symfony 7's UserInterface; removed from the interface in Symfony 8.
+    public function eraseCredentials(): void {}
 }

--- a/tests/Fixtures/Proxy/ChildProxy.php
+++ b/tests/Fixtures/Proxy/ChildProxy.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Proxy;
+
+use Doctrine\Persistence\Proxy;
+
+/**
+ * Stands in for a Doctrine proxy: implements Proxy and extends a concrete parent,
+ * so SubjectHelper::getSubjectClass() unwinds it to ProxyParent.
+ *
+ * @template-implements Proxy<ProxyParent>
+ */
+class ChildProxy extends ProxyParent implements Proxy
+{
+    public function __load(): void {}
+
+    public function __isInitialized(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/Proxy/OrphanProxy.php
+++ b/tests/Fixtures/Proxy/OrphanProxy.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Proxy;
+
+use Doctrine\Persistence\Proxy;
+
+/**
+ * A proxy with no parent class, so the manual proxy-unwind in
+ * SubjectHelper::getSubjectClass() cannot resolve a concrete class and throws.
+ *
+ * @template-implements Proxy<object>
+ */
+class OrphanProxy implements Proxy
+{
+    public function __load(): void {}
+
+    public function __isInitialized(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/Proxy/ProxyParent.php
+++ b/tests/Fixtures/Proxy/ProxyParent.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Proxy;
+
+/**
+ * Concrete class that a proxy fixture extends; the proxy-unwind resolves to this.
+ */
+class ProxyParent {}

--- a/tests/Fixtures/Security/FakeUser.php
+++ b/tests/Fixtures/Security/FakeUser.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Security;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Minimal Symfony user used to build audit tokens in tests.
+ */
+class FakeUser implements UserInterface
+{
+    /** @param list<string> $roles */
+    public function __construct(
+        private string $identifier = 'user@example.com',
+        private array $roles = ['ROLE_USER'],
+    ) {}
+
+    /** @return list<string> */
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->identifier;
+    }
+}

--- a/tests/Fixtures/Security/FakeUser.php
+++ b/tests/Fixtures/Security/FakeUser.php
@@ -25,4 +25,7 @@ class FakeUser implements UserInterface
     {
         return $this->identifier;
     }
+
+    // Required by Symfony 7's UserInterface; removed from the interface in Symfony 8.
+    public function eraseCredentials(): void {}
 }

--- a/tests/Fixtures/Subject/JsonSerializableObject.php
+++ b/tests/Fixtures/Subject/JsonSerializableObject.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Subject;
+
+/**
+ * Identifier that SubjectHelper::identifierToString() serialises via json_encode().
+ */
+class JsonSerializableObject implements \JsonSerializable
+{
+    /** @return array<string, mixed> */
+    public function jsonSerialize(): array
+    {
+        return ['type' => 'fixture', 'id' => 7];
+    }
+}

--- a/tests/Fixtures/Subject/MethodIdObject.php
+++ b/tests/Fixtures/Subject/MethodIdObject.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Subject;
+
+/**
+ * Exposes its identifier through a parameterless getId() method.
+ */
+class MethodIdObject
+{
+    public function __construct(private int $value = 99) {}
+
+    public function getId(): int
+    {
+        return $this->value;
+    }
+}

--- a/tests/Fixtures/Subject/PlainObject.php
+++ b/tests/Fixtures/Subject/PlainObject.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Subject;
+
+/**
+ * Carries no identifier of any kind and is not stringable, so it doubles as the
+ * "no identifier" case (getObjectIdentifier returns null) and the "cannot convert
+ * to string" case (identifierToString throws).
+ */
+class PlainObject {}

--- a/tests/Fixtures/Subject/PropertyIdObject.php
+++ b/tests/Fixtures/Subject/PropertyIdObject.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Subject;
+
+/**
+ * Plain object whose identifier is exposed through an initialized `id` property.
+ */
+class PropertyIdObject
+{
+    private int $id;
+
+    public function __construct(int $id = 42)
+    {
+        $this->id = $id;
+    }
+}

--- a/tests/Fixtures/Subject/RequiredParamIdObject.php
+++ b/tests/Fixtures/Subject/RequiredParamIdObject.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Subject;
+
+/**
+ * getId() requires an argument, so SubjectHelper::getIdMethod() must refuse to
+ * invoke it and return null.
+ */
+class RequiredParamIdObject
+{
+    public function getId(int $discriminator): int
+    {
+        return $discriminator;
+    }
+}

--- a/tests/Fixtures/Subject/StringableObject.php
+++ b/tests/Fixtures/Subject/StringableObject.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Subject;
+
+/**
+ * Identifier that converts to a string via Stringable.
+ */
+class StringableObject implements \Stringable
+{
+    public function __construct(private string $value = 'stringable-id') {}
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Fixtures/Subject/UninitializedIdEntity.php
+++ b/tests/Fixtures/Subject/UninitializedIdEntity.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Subject;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Carries an `#[ORM\Id]` attribute on an uninitialized typed property, so
+ * SubjectHelper::getIdAttributes() must return null rather than read it.
+ * Deliberately not an `#[ORM\Entity]` (never mapped/persisted).
+ */
+class UninitializedIdEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    private int $id;
+}

--- a/tests/Fixtures/Subject/UninitializedPropertyIdObject.php
+++ b/tests/Fixtures/Subject/UninitializedPropertyIdObject.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Fixtures\Subject;
+
+/**
+ * Has an `id` property that is never initialized, so getIdProperty() returns null.
+ */
+class UninitializedPropertyIdObject
+{
+    private int $id;
+}

--- a/tests/Integration/PresenterTest.php
+++ b/tests/Integration/PresenterTest.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Integration;
+
+use WeDevelop\Audit\Enum\AuditSource;
+use WeDevelop\Audit\Exception\UnknownAuditLogException;
+use WeDevelop\Audit\Presenter;
+use WeDevelop\Audit\Tests\Fixtures\Audit\ConcreteAuditEntity;
+use WeDevelop\Audit\Tests\Fixtures\Audit\ConcreteAuditLog;
+use WeDevelop\Audit\Tests\Support\DoctrineTestCase;
+
+final class PresenterTest extends DoctrineTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createSchema([ConcreteAuditEntity::class]);
+    }
+
+    public function testFetchReturnsLogsNewestFirst(): void
+    {
+        $this->persistLog(1, '2026-01-01 10:00:00');
+        $this->persistLog(2, '2026-01-03 10:00:00');
+        $this->persistLog(3, '2026-01-02 10:00:00');
+        $this->em->flush();
+
+        $logs = iterator_to_array($this->presenter()->fetch());
+
+        self::assertSame(
+            ['2026-01-03 10:00:00', '2026-01-02 10:00:00', '2026-01-01 10:00:00'],
+            array_map(static fn (object $log): string => $log->getLoggedAt()->format('Y-m-d H:i:s'), $logs),
+        );
+    }
+
+    public function testFetchReturnsOnlyTheRequestedPage(): void
+    {
+        $this->persistLog(1, '2026-01-01 10:00:00');
+        $this->persistLog(2, '2026-01-02 10:00:00');
+        $this->persistLog(3, '2026-01-03 10:00:00');
+        $this->em->flush();
+
+        $page = iterator_to_array($this->presenter()->fetch(page: 2, pageSize: 2));
+
+        self::assertCount(1, $page);
+        self::assertSame('2026-01-01 10:00:00', $page[0]->getLoggedAt()->format('Y-m-d H:i:s'));
+    }
+
+    public function testFetchThrowsWhenAStoredActionIsNotAnAuditLog(): void
+    {
+        $this->em->persist(ConcreteAuditEntity::create(1, \stdClass::class, AuditSource::UI, new \DateTimeImmutable()));
+        $this->em->flush();
+
+        $this->expectException(UnknownAuditLogException::class);
+        iterator_to_array($this->presenter()->fetch());
+    }
+
+    private function presenter(): Presenter
+    {
+        return new Presenter($this->registryReturningEntityManager(), ConcreteAuditEntity::class);
+    }
+
+    private function persistLog(int $id, string $createdAt): void
+    {
+        $this->em->persist(
+            ConcreteAuditEntity::create($id, ConcreteAuditLog::class, AuditSource::UI, new \DateTimeImmutable($createdAt)),
+        );
+    }
+}

--- a/tests/Integration/Util/SubjectHelperDoctrineTest.php
+++ b/tests/Integration/Util/SubjectHelperDoctrineTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Integration\Util;
+
+use WeDevelop\Audit\Tests\Fixtures\Doctrine\CompositeIdEntity;
+use WeDevelop\Audit\Tests\Fixtures\Doctrine\IntegrationEntity;
+use WeDevelop\Audit\Tests\Support\DoctrineTestCase;
+use WeDevelop\Audit\Util\SubjectHelper;
+
+final class SubjectHelperDoctrineTest extends DoctrineTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createSchema([IntegrationEntity::class, CompositeIdEntity::class]);
+        SubjectHelper::setManagerRegistry($this->registryReturningEntityManager());
+    }
+
+    public function testReadsSingleIdentifierFromDoctrineMetadata(): void
+    {
+        $entity = new IntegrationEntity(5);
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        self::assertSame(5, SubjectHelper::getObjectIdentifier($entity));
+    }
+
+    public function testReadsCompositeIdentifierFromDoctrineMetadata(): void
+    {
+        $entity = new CompositeIdEntity(1, 'abc');
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        self::assertSame(['first' => 1, 'second' => 'abc'], SubjectHelper::getObjectIdentifier($entity));
+    }
+
+    public function testResolvesConcreteClassFromADoctrineProxy(): void
+    {
+        $this->em->persist(new IntegrationEntity(5));
+        $this->em->flush();
+        $this->em->clear();
+
+        $proxy = $this->em->getReference(IntegrationEntity::class, 5);
+        self::assertNotNull($proxy);
+
+        self::assertSame(IntegrationEntity::class, SubjectHelper::getSubjectClass($proxy));
+    }
+}

--- a/tests/Integration/ValueObject/ContextRefDbTest.php
+++ b/tests/Integration/ValueObject/ContextRefDbTest.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Integration\ValueObject;
+
+use Symfony\Component\HttpFoundation\Request;
+use WeDevelop\Audit\Security\AuditImpersonationToken;
+use WeDevelop\Audit\Security\AuditToken;
+use WeDevelop\Audit\Tests\Fixtures\Doctrine\UserEntity;
+use WeDevelop\Audit\Tests\Support\DoctrineTestCase;
+use WeDevelop\Audit\ValueObject\Context;
+
+final class ContextRefDbTest extends DoctrineTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createSchema([UserEntity::class]);
+    }
+
+    public function testRefDbLeavesManagedUsersUntouched(): void
+    {
+        $user = new UserEntity(1, 'alice');
+        $this->em->persist($user);
+        $this->em->flush();
+
+        $context = $this->contextFor($user);
+
+        self::assertSame($user, $context->refDb($this->em)->token?->getUser());
+    }
+
+    public function testRefDbReplacesDetachedUsersWithManagedReferences(): void
+    {
+        $user = new UserEntity(1, 'alice');
+        $this->em->persist($user);
+        $this->em->flush();
+        $this->em->clear();
+
+        $resolved = $this->contextFor($user)->refDb($this->em)->token?->getUser();
+
+        self::assertInstanceOf(UserEntity::class, $resolved);
+        self::assertNotSame($user, $resolved);
+        self::assertTrue($this->em->contains($resolved));
+        self::assertSame(1, $resolved->getId());
+    }
+
+    public function testRefDbResolvesBothSidesOfAnImpersonationToken(): void
+    {
+        $user = new UserEntity(1, 'alice');
+        $admin = new UserEntity(2, 'admin');
+        $this->em->persist($user);
+        $this->em->persist($admin);
+        $this->em->flush();
+
+        $token = new AuditImpersonationToken($user, new AuditToken($admin));
+        $context = Context::ui(Request::create('/', server: ['REMOTE_ADDR' => '192.0.2.1']), $token);
+
+        $refreshed = $context->refDb($this->em)->token;
+
+        self::assertInstanceOf(AuditImpersonationToken::class, $refreshed);
+        self::assertSame($user, $refreshed->getUser());
+        self::assertSame($admin, $refreshed->getOriginalToken()->getUser());
+    }
+
+    private function contextFor(UserEntity $user): Context
+    {
+        return Context::ui(Request::create('/', server: ['REMOTE_ADDR' => '192.0.2.1']), new AuditToken($user));
+    }
+}

--- a/tests/Support/DoctrineTestCase.php
+++ b/tests/Support/DoctrineTestCase.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Support;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Boots a real Doctrine ORM EntityManager backed by in-memory SQLite, so the
+ * integration tests exercise genuine metadata, identifier extraction and proxy
+ * behaviour. Uses only APIs shared by ORM 2.x and 3.x (the constructor rather
+ * than the removed EntityManager::create(), and a params-array DBAL connection)
+ * so the same bootstrap runs on both CI dependency sets.
+ */
+abstract class DoctrineTestCase extends TestCase
+{
+    use ResetsSubjectHelperRegistry;
+    protected EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $config = ORMSetup::createAttributeMetadataConfiguration(
+            [dirname(__DIR__) . '/Fixtures/Doctrine', dirname(__DIR__) . '/Fixtures/Audit'],
+            true,
+            null,
+            new ArrayAdapter(),
+        );
+
+        // On PHP 8.4+, ORM 3 with Symfony 8's var-exporter (which dropped
+        // LazyGhostTrait) needs native lazy objects for proxies. Enable them where
+        // available; on PHP 8.2/8.3 the Symfony 7 LazyGhost and ORM 2.x's own proxy
+        // mechanism are used instead, so the same bootstrap covers every CI cell.
+        if (\PHP_VERSION_ID >= 80400 && method_exists($config, 'enableNativeLazyObjects')) {
+            $config->enableNativeLazyObjects(true);
+        }
+
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true], $config);
+        $this->em = new EntityManager($connection, $config);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetSubjectHelperRegistry();
+    }
+
+    /** @param list<class-string> $classes */
+    protected function createSchema(array $classes): void
+    {
+        $metadata = array_map(
+            fn (string $class): object => $this->em->getClassMetadata($class),
+            $classes,
+        );
+        (new SchemaTool($this->em))->createSchema($metadata);
+    }
+
+    /** A ManagerRegistry that routes every class to the test EntityManager. */
+    protected function registryReturningEntityManager(): ManagerRegistry
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($this->em);
+        $registry->method('getManager')->willReturn($this->em);
+        $registry->method('getRepository')->willReturnCallback(
+            fn (string $class): object => $this->em->getRepository($class),
+        );
+
+        return $registry;
+    }
+}

--- a/tests/Support/ResetsSubjectHelperRegistry.php
+++ b/tests/Support/ResetsSubjectHelperRegistry.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Support;
+
+use WeDevelop\Audit\Util\SubjectHelper;
+
+/**
+ * SubjectHelper keeps its ManagerRegistry in a mutable static with no public
+ * reset, so any test that sets one must clear it afterwards to avoid leaking
+ * into later tests. The production API is intentionally left untouched.
+ */
+trait ResetsSubjectHelperRegistry
+{
+    protected function resetSubjectHelperRegistry(): void
+    {
+        (new \ReflectionProperty(SubjectHelper::class, 'registry'))->setValue(null, null);
+    }
+}

--- a/tests/Unit/AbstractAuditLogTest.php
+++ b/tests/Unit/AbstractAuditLogTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use WeDevelop\Audit\AbstractAuditLog;
+use WeDevelop\Audit\Enum\AuditSource;
+use WeDevelop\Audit\Security\AuditToken;
+use WeDevelop\Audit\Tests\Fixtures\Audit\ConcreteAuditEntity;
+use WeDevelop\Audit\Tests\Fixtures\Audit\ConcreteAuditLog;
+use WeDevelop\Audit\Tests\Fixtures\Doctrine\IntegrationEntity;
+use WeDevelop\Audit\Tests\Fixtures\Security\FakeUser;
+use WeDevelop\Audit\ValueObject\Context;
+
+final class AbstractAuditLogTest extends TestCase
+{
+    public function testFromEntityRejectsAbstractClasses(): void
+    {
+        $entity = ConcreteAuditEntity::create(1, 'irrelevant', AuditSource::CONSOLE, new \DateTimeImmutable());
+
+        $this->expectException(\LogicException::class);
+        AbstractAuditLog::fromEntity($entity);
+    }
+
+    public function testFromEntityReconstructsAConcreteLog(): void
+    {
+        $createdAt = new \DateTimeImmutable('2026-03-04 05:06:07');
+        $user = new FakeUser('alice');
+        $entity = ConcreteAuditEntity::create(
+            id: 1,
+            action: ConcreteAuditLog::class,
+            source: AuditSource::UI,
+            createdAt: $createdAt,
+            subjectClass: IntegrationEntity::class,
+            subjectIdentifier: '5',
+            data: ['method' => 'totp'],
+            ipAddress: '198.51.100.7',
+            user: $user,
+        );
+
+        $log = ConcreteAuditLog::fromEntity($entity);
+
+        self::assertInstanceOf(ConcreteAuditLog::class, $log);
+        self::assertSame($createdAt, $log->getLoggedAt());
+        self::assertSame(['method' => 'totp'], $log->getData());
+
+        $subject = $log->getSubject();
+        self::assertNotNull($subject);
+        self::assertSame(IntegrationEntity::class, $subject->class);
+        self::assertSame('5', $subject->identifier);
+
+        $context = $log->getContext();
+        self::assertSame(AuditSource::UI, $context->source);
+        self::assertNotNull($context->ip);
+        self::assertSame('198.51.100.7', $context->ip->address);
+        self::assertInstanceOf(AuditToken::class, $context->token);
+        self::assertSame($user, $context->token->getUser());
+    }
+
+    public function testTransNamespacesTheMessageAndForwardsParameters(): void
+    {
+        $log = ConcreteAuditLog::create(Context::console(), null, new \DateTimeImmutable(), null);
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->once())
+            ->method('trans')
+            ->with('action.user.mfa.enabled', ['%user%' => 'alice'], 'audit', null)
+            ->willReturn('Translated message');
+
+        self::assertSame('Translated message', $log->trans($translator));
+    }
+
+    public function testGetInfoYieldsStringEntriesAndTranslatableMessages(): void
+    {
+        $log = ConcreteAuditLog::create(Context::console(), null, new \DateTimeImmutable(), null);
+
+        $info = iterator_to_array($log->getInfo(), false);
+
+        self::assertCount(2, $info);
+        self::assertSame('user.mfa.enabled.summary', $info[0]);
+        self::assertInstanceOf(TranslatableMessage::class, $info[1]);
+        self::assertSame('info.user.mfa.enabled.method', $info[1]->getMessage());
+        self::assertSame(['%name%' => 'totp'], $info[1]->getParameters());
+        self::assertSame('audit', $info[1]->getDomain());
+    }
+}

--- a/tests/Unit/Entity/AbstractAuditEntityTest.php
+++ b/tests/Unit/Entity/AbstractAuditEntityTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit\Entity;
+
+use PHPUnit\Framework\TestCase;
+use WeDevelop\Audit\Entity\Subject;
+use WeDevelop\Audit\Enum\AuditSource;
+use WeDevelop\Audit\Tests\Fixtures\Audit\ConcreteAuditEntity;
+use WeDevelop\Audit\Tests\Fixtures\Doctrine\IntegrationEntity;
+
+final class AbstractAuditEntityTest extends TestCase
+{
+    public function testExposesStoredColumns(): void
+    {
+        $createdAt = new \DateTimeImmutable('2026-01-02 03:04:05');
+        $entity = ConcreteAuditEntity::create(
+            id: 1,
+            action: 'App\\Audit\\Something',
+            source: AuditSource::API,
+            createdAt: $createdAt,
+            data: ['key' => 'value'],
+            ipAddress: '203.0.113.5',
+        );
+
+        self::assertSame('App\\Audit\\Something', $entity->getAction());
+        self::assertSame(AuditSource::API, $entity->getSource());
+        self::assertSame($createdAt, $entity->getCreatedAt());
+        self::assertSame(['key' => 'value'], $entity->getData());
+        self::assertSame('203.0.113.5', $entity->getIpAddress());
+    }
+
+    public function testGetSubjectReturnsTheEmbeddedSubjectWhenPresent(): void
+    {
+        $subject = new Subject(IntegrationEntity::class, 5);
+        $entity = ConcreteAuditEntity::create(1, 'App\\Action', AuditSource::UI, new \DateTimeImmutable(), subject: $subject);
+
+        self::assertSame($subject, $entity->getSubject());
+    }
+
+    public function testGetSubjectRebuildsFromClassAndIdentifierColumns(): void
+    {
+        $entity = ConcreteAuditEntity::create(
+            1,
+            'App\\Action',
+            AuditSource::UI,
+            new \DateTimeImmutable(),
+            subjectClass: IntegrationEntity::class,
+            subjectIdentifier: '5',
+        );
+
+        $subject = $entity->getSubject();
+
+        self::assertNotNull($subject);
+        self::assertSame(IntegrationEntity::class, $subject->class);
+        self::assertSame('5', $subject->identifier);
+    }
+
+    public function testGetSubjectReturnsNullWhenNoSubjectStored(): void
+    {
+        $entity = ConcreteAuditEntity::create(1, 'App\\Action', AuditSource::UI, new \DateTimeImmutable());
+
+        self::assertNull($entity->getSubject());
+    }
+}

--- a/tests/Unit/Entity/SubjectTest.php
+++ b/tests/Unit/Entity/SubjectTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit\Entity;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use WeDevelop\Audit\Entity\Subject;
+use WeDevelop\Audit\Exception\SubjectNotConcreteException;
+use WeDevelop\Audit\Tests\Fixtures\Doctrine\IntegrationEntity;
+use WeDevelop\Audit\Tests\Fixtures\Subject\PropertyIdObject;
+
+final class SubjectTest extends TestCase
+{
+    public function testFromObjectReturnsNullForNull(): void
+    {
+        self::assertNull(Subject::fromObject(null));
+    }
+
+    /** @param class-string $expectedClass */
+    #[DataProvider('subjectObjects')]
+    public function testFromObjectCapturesClassAndIdentifier(object $object, string $expectedClass, string $expectedIdentifier): void
+    {
+        $subject = Subject::fromObject($object);
+
+        self::assertNotNull($subject);
+        self::assertSame($expectedClass, $subject->class);
+        self::assertSame($expectedIdentifier, $subject->identifier);
+    }
+
+    /** @return iterable<string, array{object, class-string, string}> */
+    public static function subjectObjects(): iterable
+    {
+        yield 'doctrine entity' => [new IntegrationEntity(5), IntegrationEntity::class, '5'];
+        yield 'plain object with id property' => [new PropertyIdObject(7), PropertyIdObject::class, '7'];
+    }
+
+    public function testConstructorStringifiesComplexIdentifiers(): void
+    {
+        $subject = new Subject(IntegrationEntity::class, ['tenant' => 1, 'ref' => 'abc']);
+
+        self::assertSame('{"tenant":1,"ref":"abc"}', $subject->identifier);
+    }
+
+    public function testFromObjectRejectsAnonymousClasses(): void
+    {
+        $this->expectException(SubjectNotConcreteException::class);
+        Subject::fromObject(new class {});
+    }
+
+    public function testConstructorRejectsAnonymousClasses(): void
+    {
+        $anonymous = new class {};
+
+        $this->expectException(SubjectNotConcreteException::class);
+        new Subject($anonymous::class);
+    }
+}

--- a/tests/Unit/Enum/AuditSourceTest.php
+++ b/tests/Unit/Enum/AuditSourceTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit\Enum;
+
+use PHPUnit\Framework\TestCase;
+use WeDevelop\Audit\Enum\AuditSource;
+
+final class AuditSourceTest extends TestCase
+{
+    public function testBackingValues(): void
+    {
+        self::assertSame('console', AuditSource::CONSOLE->value);
+        self::assertSame('ui', AuditSource::UI->value);
+        self::assertSame('api', AuditSource::API->value);
+        self::assertSame('webhook', AuditSource::WEBHOOK->value);
+        self::assertSame('job', AuditSource::JOB->value);
+        self::assertSame('unknown', AuditSource::UNKNOWN->value);
+    }
+
+    public function testHasExactlySixCases(): void
+    {
+        self::assertCount(6, AuditSource::cases());
+    }
+}

--- a/tests/Unit/Exception/ExceptionTest.php
+++ b/tests/Unit/Exception/ExceptionTest.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit\Exception;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use WeDevelop\Audit\Enum\AuditSource;
+use WeDevelop\Audit\Exception\AuditExceptionInterface;
+use WeDevelop\Audit\Exception\IdentifierStringConversionException;
+use WeDevelop\Audit\Exception\SubjectNotConcreteException;
+use WeDevelop\Audit\Exception\UnknownAuditLogException;
+use WeDevelop\Audit\Tests\Fixtures\Audit\ConcreteAuditEntity;
+
+final class ExceptionTest extends TestCase
+{
+    #[DataProvider('unconvertibleIdentifierTypes')]
+    public function testIdentifierStringConversionExceptionReportsTheType(string $expectedType, mixed $identifier): void
+    {
+        $exception = new IdentifierStringConversionException($identifier);
+
+        self::assertInstanceOf(AuditExceptionInterface::class, $exception);
+        self::assertSame(
+            sprintf('Cannot convert identifier of type "%s" to a string', $expectedType),
+            $exception->getMessage(),
+        );
+    }
+
+    /** @return iterable<string, array{string, mixed}> */
+    public static function unconvertibleIdentifierTypes(): iterable
+    {
+        yield 'array' => ['array', ['a' => 1]];
+        yield 'int' => ['int', 123];
+        yield 'object' => ['stdClass', new \stdClass()];
+    }
+
+    public function testIdentifierStringConversionExceptionChainsThePreviousError(): void
+    {
+        $previous = new \JsonException('boom');
+
+        self::assertSame($previous, (new IdentifierStringConversionException(['a' => 1], $previous))->getPrevious());
+    }
+
+    public function testSubjectNotConcreteExceptionMessage(): void
+    {
+        $exception = new SubjectNotConcreteException();
+
+        self::assertInstanceOf(AuditExceptionInterface::class, $exception);
+        self::assertSame(
+            'Subject not concrete (anonymous classes cannot be referenced in audit logs)',
+            $exception->getMessage(),
+        );
+    }
+
+    public function testUnknownAuditLogExceptionExposesTheOffendingEntityAndClass(): void
+    {
+        $entity = ConcreteAuditEntity::create(1, 'App\\Audit\\Gone', AuditSource::UI, new \DateTimeImmutable());
+
+        $exception = new UnknownAuditLogException($entity);
+
+        self::assertInstanceOf(AuditExceptionInterface::class, $exception);
+        self::assertSame(
+            'Audit Entity references an Audit Log class "App\Audit\Gone" that is unknown',
+            $exception->getMessage(),
+        );
+        self::assertSame($entity, $exception->getEntity());
+        self::assertSame('App\Audit\Gone', $exception->getAuditLogClass());
+    }
+}

--- a/tests/Unit/PresenterTest.php
+++ b/tests/Unit/PresenterTest.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use WeDevelop\Audit\Enum\AuditSource;
+use WeDevelop\Audit\Exception\UnknownAuditLogException;
+use WeDevelop\Audit\Presenter;
+use WeDevelop\Audit\Tests\Fixtures\Audit\ConcreteAuditEntity;
+use WeDevelop\Audit\Tests\Fixtures\Audit\ConcreteAuditLog;
+
+final class PresenterTest extends TestCase
+{
+    /**
+     * @param array<string, mixed>|null $criteria
+     * @param array<string, mixed> $expectedCriteria
+     */
+    #[DataProvider('pagingCases')]
+    public function testFetchTranslatesPagingIntoLimitAndOffset(
+        ?array $criteria,
+        ?int $page,
+        int $pageSize,
+        array $expectedCriteria,
+        ?int $expectedLimit,
+        ?int $expectedOffset,
+    ): void {
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('findBy')
+            ->with($expectedCriteria, ['createdAt' => 'DESC'], $expectedLimit, $expectedOffset)
+            ->willReturn([]);
+
+        $presenter = new Presenter($this->registryFor($repository), ConcreteAuditEntity::class);
+
+        iterator_to_array($presenter->fetch($criteria, $page, $pageSize));
+    }
+
+    /** @return iterable<string, array{?array<string, mixed>, ?int, int, array<string, mixed>, ?int, ?int}> */
+    public static function pagingCases(): iterable
+    {
+        yield 'no page means no limit or offset' => [null, null, 50, [], null, null];
+        yield 'first page starts at offset zero' => [['source' => 'ui'], 1, 10, ['source' => 'ui'], 10, 0];
+        yield 'third page offsets by two pages' => [null, 3, 10, [], 10, 20];
+        yield 'page zero clamps the offset to zero' => [null, 0, 10, [], 10, 0];
+    }
+
+    public function testFetchReconstructsAuditLogsFromEntities(): void
+    {
+        $entity = ConcreteAuditEntity::create(1, ConcreteAuditLog::class, AuditSource::UI, new \DateTimeImmutable());
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->method('findBy')->willReturn([$entity]);
+
+        $presenter = new Presenter($this->registryFor($repository), ConcreteAuditEntity::class);
+
+        $logs = iterator_to_array($presenter->fetch());
+
+        self::assertCount(1, $logs);
+        self::assertInstanceOf(ConcreteAuditLog::class, $logs[0]);
+    }
+
+    public function testFetchThrowsWhenTheActionIsNotAnAuditLog(): void
+    {
+        $entity = ConcreteAuditEntity::create(1, \stdClass::class, AuditSource::UI, new \DateTimeImmutable());
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->method('findBy')->willReturn([$entity]);
+
+        $presenter = new Presenter($this->registryFor($repository), ConcreteAuditEntity::class);
+
+        $this->expectException(UnknownAuditLogException::class);
+        iterator_to_array($presenter->fetch());
+    }
+
+    /** @param ObjectRepository<ConcreteAuditEntity> $repository */
+    private function registryFor(ObjectRepository $repository): ManagerRegistry
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->willReturn($repository);
+
+        return $registry;
+    }
+}

--- a/tests/Unit/Security/AuditImpersonationTokenTest.php
+++ b/tests/Unit/Security/AuditImpersonationTokenTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit\Security;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use WeDevelop\Audit\Security\AuditImpersonationToken;
+use WeDevelop\Audit\Security\AuditToken;
+use WeDevelop\Audit\Tests\Fixtures\Security\FakeUser;
+
+final class AuditImpersonationTokenTest extends TestCase
+{
+    public function testRetainsImpersonatedUserOriginalTokenAndOriginalRoles(): void
+    {
+        $impersonated = new FakeUser('alice', ['ROLE_USER']);
+        $admin = new FakeUser('admin', ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH']);
+        $originalToken = new AuditToken($admin);
+
+        $token = new AuditImpersonationToken($impersonated, $originalToken);
+
+        self::assertInstanceOf(SwitchUserToken::class, $token);
+        self::assertSame(AuditToken::DEFAULT_FIREWALL_NAME, $token->getFirewallName());
+        self::assertSame($impersonated, $token->getUser());
+        self::assertSame($originalToken, $token->getOriginalToken());
+        // Roles come from the original (impersonating) user, not the target.
+        self::assertSame(['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'], $token->getRoleNames());
+    }
+
+    public function testAcceptsCustomFirewallName(): void
+    {
+        $token = new AuditImpersonationToken(
+            new FakeUser('alice'),
+            new AuditToken(new FakeUser('admin')),
+            'main',
+        );
+
+        self::assertSame('main', $token->getFirewallName());
+    }
+}

--- a/tests/Unit/Security/AuditTokenTest.php
+++ b/tests/Unit/Security/AuditTokenTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit\Security;
+
+use PHPUnit\Framework\TestCase;
+use WeDevelop\Audit\Security\AuditToken;
+use WeDevelop\Audit\Tests\Fixtures\Security\FakeUser;
+
+final class AuditTokenTest extends TestCase
+{
+    public function testUsesDefaultFirewallAndUserRoles(): void
+    {
+        $user = new FakeUser('alice', ['ROLE_USER', 'ROLE_EDITOR']);
+
+        $token = new AuditToken($user);
+
+        self::assertSame(AuditToken::DEFAULT_FIREWALL_NAME, $token->getFirewallName());
+        self::assertSame($user, $token->getUser());
+        self::assertSame(['ROLE_USER', 'ROLE_EDITOR'], $token->getRoleNames());
+    }
+
+    public function testAcceptsCustomFirewallName(): void
+    {
+        $token = new AuditToken(new FakeUser(), 'main');
+
+        self::assertSame('main', $token->getFirewallName());
+    }
+}

--- a/tests/Unit/Util/SubjectHelperTest.php
+++ b/tests/Unit/Util/SubjectHelperTest.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit\Util;
+
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use WeDevelop\Audit\Exception\IdentifierStringConversionException;
+use WeDevelop\Audit\Exception\SubjectNotConcreteException;
+use WeDevelop\Audit\Tests\Fixtures\Doctrine\CompositeIdEntity;
+use WeDevelop\Audit\Tests\Fixtures\Doctrine\IntegrationEntity;
+use WeDevelop\Audit\Tests\Fixtures\Proxy\ChildProxy;
+use WeDevelop\Audit\Tests\Fixtures\Proxy\OrphanProxy;
+use WeDevelop\Audit\Tests\Fixtures\Proxy\ProxyParent;
+use WeDevelop\Audit\Tests\Fixtures\Subject\JsonSerializableObject;
+use WeDevelop\Audit\Tests\Fixtures\Subject\MethodIdObject;
+use WeDevelop\Audit\Tests\Fixtures\Subject\PlainObject;
+use WeDevelop\Audit\Tests\Fixtures\Subject\PropertyIdObject;
+use WeDevelop\Audit\Tests\Fixtures\Subject\RequiredParamIdObject;
+use WeDevelop\Audit\Tests\Fixtures\Subject\StringableObject;
+use WeDevelop\Audit\Tests\Fixtures\Subject\UninitializedIdEntity;
+use WeDevelop\Audit\Tests\Fixtures\Subject\UninitializedPropertyIdObject;
+use WeDevelop\Audit\Tests\Support\ResetsSubjectHelperRegistry;
+use WeDevelop\Audit\Util\SubjectHelper;
+
+final class SubjectHelperTest extends TestCase
+{
+    use ResetsSubjectHelperRegistry;
+
+    protected function tearDown(): void
+    {
+        $this->resetSubjectHelperRegistry();
+    }
+
+    public function testAssertObjectConcreteAcceptsConcreteClasses(): void
+    {
+        $this->expectNotToPerformAssertions();
+        SubjectHelper::assertObjectConcrete(PropertyIdObject::class);
+    }
+
+    public function testAssertObjectConcreteRejectsAnonymousClasses(): void
+    {
+        $this->expectException(SubjectNotConcreteException::class);
+        SubjectHelper::assertObjectConcrete(new class {});
+    }
+
+    public function testGetSubjectClassReturnsConcreteClass(): void
+    {
+        self::assertSame(PropertyIdObject::class, SubjectHelper::getSubjectClass(new PropertyIdObject()));
+    }
+
+    public function testGetSubjectClassUnwindsProxyToItsParent(): void
+    {
+        self::assertSame(ProxyParent::class, SubjectHelper::getSubjectClass(new ChildProxy()));
+    }
+
+    public function testGetSubjectClassRejectsParentlessProxy(): void
+    {
+        $this->expectException(SubjectNotConcreteException::class);
+        SubjectHelper::getSubjectClass(new OrphanProxy());
+    }
+
+    public function testGetSubjectClassSwallowsRegistryErrorsAndFallsBack(): void
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willThrowException(new \RuntimeException('registry down'));
+        SubjectHelper::setManagerRegistry($registry);
+
+        self::assertSame(PropertyIdObject::class, SubjectHelper::getSubjectClass(new PropertyIdObject()));
+    }
+
+    #[DataProvider('objectIdentifierCases')]
+    public function testGetObjectIdentifier(mixed $expected, object $subject): void
+    {
+        self::assertSame($expected, SubjectHelper::getObjectIdentifier($subject));
+    }
+
+    /** @return iterable<string, array{mixed, object}> */
+    public static function objectIdentifierCases(): iterable
+    {
+        yield 'doctrine id attribute' => [5, new IntegrationEntity(5)];
+        yield 'composite doctrine id attributes' => [['first' => 1, 'second' => 'abc'], new CompositeIdEntity(1, 'abc')];
+        yield 'id property' => [42, new PropertyIdObject()];
+        yield 'getId() method' => [99, new MethodIdObject()];
+        yield 'getId() requiring arguments is ignored' => [null, new RequiredParamIdObject()];
+        yield 'uninitialized id attribute' => [null, new UninitializedIdEntity()];
+        yield 'uninitialized id property' => [null, new UninitializedPropertyIdObject()];
+        yield 'no identifier at all' => [null, new PlainObject()];
+    }
+
+    #[DataProvider('identifierStringCases')]
+    public function testIdentifierToString(?string $expected, mixed $identifier): void
+    {
+        self::assertSame($expected, SubjectHelper::identifierToString($identifier));
+    }
+
+    /** @return iterable<string, array{?string, mixed}> */
+    public static function identifierStringCases(): iterable
+    {
+        yield 'null stays null' => [null, null];
+        yield 'true becomes the word true' => ['true', true];
+        yield 'false becomes the word false' => ['false', false];
+        yield 'integer is cast' => ['42', 42];
+        yield 'string passes through' => ['foo', 'foo'];
+        yield 'float is cast' => ['3.5', 3.5];
+        yield 'array is json encoded' => ['{"a":1}', ['a' => 1]];
+        yield 'stringable is cast' => ['stringable-id', new StringableObject()];
+        yield 'json serializable is encoded' => ['{"type":"fixture","id":7}', new JsonSerializableObject()];
+    }
+
+    #[DataProvider('unconvertibleIdentifiers')]
+    public function testIdentifierToStringThrowsForUnconvertibleValues(mixed $identifier): void
+    {
+        $this->expectException(IdentifierStringConversionException::class);
+        SubjectHelper::identifierToString($identifier);
+    }
+
+    /** @return iterable<string, array{mixed}> */
+    public static function unconvertibleIdentifiers(): iterable
+    {
+        yield 'array that cannot be json encoded' => [['unencodable' => \INF]];
+        yield 'object that is not stringable' => [new PlainObject()];
+    }
+}

--- a/tests/Unit/Util/SubjectHelperTest.php
+++ b/tests/Unit/Util/SubjectHelperTest.php
@@ -69,6 +69,15 @@ final class SubjectHelperTest extends TestCase
         self::assertSame(PropertyIdObject::class, SubjectHelper::getSubjectClass(new PropertyIdObject()));
     }
 
+    public function testGetDoctrinePropertiesReturnsNullWhenTheRegistryFails(): void
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willThrowException(new \RuntimeException('registry down'));
+        SubjectHelper::setManagerRegistry($registry);
+
+        self::assertNull(SubjectHelper::getDoctrineProperties(new IntegrationEntity(5)));
+    }
+
     #[DataProvider('objectIdentifierCases')]
     public function testGetObjectIdentifier(mixed $expected, object $subject): void
     {

--- a/tests/Unit/Util/TranslationHelperTest.php
+++ b/tests/Unit/Util/TranslationHelperTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit\Util;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use WeDevelop\Audit\Tests\Fixtures\Subject\StringableObject;
+use WeDevelop\Audit\Util\TranslationHelper;
+
+final class TranslationHelperTest extends TestCase
+{
+    /** @param string|list<string> $namespace */
+    #[DataProvider('namespaceCases')]
+    public function testInNamespace(string $expected, string $message, string|array $namespace): void
+    {
+        self::assertSame($expected, TranslationHelper::inNamespace($message, $namespace));
+    }
+
+    /** @return iterable<string, array{string, string, string|list<string>}> */
+    public static function namespaceCases(): iterable
+    {
+        yield 'string namespace is prepended' => ['action.user.login', 'user.login', 'action'];
+        yield 'already-prefixed message is returned as-is' => ['action.user.login', 'action.user.login', 'action'];
+        yield 'array namespace is joined with dots' => ['info.user.mfa.method', 'method', ['info', 'user.mfa']];
+        yield 'leading dot on the message is trimmed' => ['action.user.login', '.user.login', 'action'];
+        yield 'surrounding dots on the namespace are trimmed' => ['action.user.login', 'user.login', '.action.'];
+    }
+
+    /**
+     * @param array<string, string> $expected
+     * @param iterable<int|string, null|scalar|\Stringable> $parameters
+     */
+    #[DataProvider('parameterCases')]
+    public function testPrepareTranslationParameters(array $expected, iterable $parameters): void
+    {
+        self::assertSame($expected, TranslationHelper::prepareTranslationParameters($parameters));
+    }
+
+    /** @return iterable<string, array{array<string, string>, iterable<int|string, null|scalar|\Stringable>}> */
+    public static function parameterCases(): iterable
+    {
+        yield 'wraps keys and stringifies values' => [
+            ['%user%' => 'alice', '%count%' => '3'],
+            ['user' => 'alice', 'count' => 3],
+        ];
+        yield 'already-wrapped keys are left intact' => [
+            ['%user%' => 'bob'],
+            ['%user%' => 'bob'],
+        ];
+        yield 'accepts an iterator and stringable values' => [
+            ['%name%' => 'totp'],
+            new \ArrayIterator(['name' => new StringableObject('totp')]),
+        ];
+    }
+}

--- a/tests/Unit/ValueObject/ContextTest.php
+++ b/tests/Unit/ValueObject/ContextTest.php
@@ -15,19 +15,24 @@ use WeDevelop\Audit\ValueObject\Context;
 
 final class ContextTest extends TestCase
 {
+    /** @param \Closure(): Context $factory */
     #[DataProvider('tokenlessFactories')]
-    public function testTokenlessFactoriesHaveNoTokenOrIp(AuditSource $expectedSource, Context $context): void
+    public function testTokenlessFactoriesHaveNoTokenOrIp(AuditSource $expectedSource, \Closure $factory): void
     {
+        // Invoke the factory in the test body (not the provider) so it is counted
+        // as covered — data providers run outside coverage measurement.
+        $context = $factory();
+
         self::assertSame($expectedSource, $context->source);
         self::assertNull($context->token);
         self::assertNull($context->ip);
     }
 
-    /** @return iterable<string, array{AuditSource, Context}> */
+    /** @return iterable<string, array{AuditSource, \Closure(): Context}> */
     public static function tokenlessFactories(): iterable
     {
-        yield 'console' => [AuditSource::CONSOLE, Context::console()];
-        yield 'job' => [AuditSource::JOB, Context::job()];
+        yield 'console' => [AuditSource::CONSOLE, static fn (): Context => Context::console()];
+        yield 'job' => [AuditSource::JOB, static fn (): Context => Context::job()];
     }
 
     /** @param \Closure(Request, AuditToken): Context $factory */

--- a/tests/Unit/ValueObject/ContextTest.php
+++ b/tests/Unit/ValueObject/ContextTest.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit\ValueObject;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use WeDevelop\Audit\Enum\AuditSource;
+use WeDevelop\Audit\Security\AuditImpersonationToken;
+use WeDevelop\Audit\Security\AuditToken;
+use WeDevelop\Audit\Tests\Fixtures\Audit\ConcreteAuditEntity;
+use WeDevelop\Audit\Tests\Fixtures\Security\FakeUser;
+use WeDevelop\Audit\ValueObject\Context;
+
+final class ContextTest extends TestCase
+{
+    #[DataProvider('tokenlessFactories')]
+    public function testTokenlessFactoriesHaveNoTokenOrIp(AuditSource $expectedSource, Context $context): void
+    {
+        self::assertSame($expectedSource, $context->source);
+        self::assertNull($context->token);
+        self::assertNull($context->ip);
+    }
+
+    /** @return iterable<string, array{AuditSource, Context}> */
+    public static function tokenlessFactories(): iterable
+    {
+        yield 'console' => [AuditSource::CONSOLE, Context::console()];
+        yield 'job' => [AuditSource::JOB, Context::job()];
+    }
+
+    /** @param \Closure(Request, AuditToken): Context $factory */
+    #[DataProvider('requestFactories')]
+    public function testRequestFactoriesCaptureSourceTokenAndClientIp(AuditSource $expectedSource, \Closure $factory): void
+    {
+        $request = Request::create('/', server: ['REMOTE_ADDR' => '192.0.2.10']);
+        $token = new AuditToken(new FakeUser());
+
+        $context = $factory($request, $token);
+
+        self::assertSame($expectedSource, $context->source);
+        self::assertSame($token, $context->token);
+        self::assertNotNull($context->ip);
+        self::assertSame('192.0.2.10', $context->ip->address);
+    }
+
+    /** @return iterable<string, array{AuditSource, \Closure(Request, AuditToken): Context}> */
+    public static function requestFactories(): iterable
+    {
+        yield 'ui' => [AuditSource::UI, static fn (Request $r, AuditToken $t): Context => Context::ui($r, $t)];
+        yield 'api' => [AuditSource::API, static fn (Request $r, AuditToken $t): Context => Context::api($r, $t)];
+        yield 'webhook with token' => [AuditSource::WEBHOOK, static fn (Request $r, AuditToken $t): Context => Context::webhook($r, $t)];
+    }
+
+    public function testWebhookDefaultsToNoTokenButStillCapturesIp(): void
+    {
+        $context = Context::webhook(Request::create('/', server: ['REMOTE_ADDR' => '192.0.2.3']));
+
+        self::assertSame(AuditSource::WEBHOOK, $context->source);
+        self::assertNull($context->token);
+        self::assertSame('192.0.2.3', (string) $context->ip);
+    }
+
+    public function testUnknownAlwaysThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        Context::unknown();
+    }
+
+    public function testFromEntityWithoutUserHasNoToken(): void
+    {
+        $entity = ConcreteAuditEntity::create(1, 'App\\Action', AuditSource::JOB, new \DateTimeImmutable(), ipAddress: '192.0.2.5');
+
+        $context = Context::fromEntity($entity);
+
+        self::assertSame(AuditSource::JOB, $context->source);
+        self::assertNull($context->token);
+        self::assertSame('192.0.2.5', (string) $context->ip);
+    }
+
+    public function testFromEntityWithUserBuildsAnAuditToken(): void
+    {
+        $user = new FakeUser('alice');
+        $entity = ConcreteAuditEntity::create(1, 'App\\Action', AuditSource::UI, new \DateTimeImmutable(), user: $user);
+
+        $context = Context::fromEntity($entity);
+
+        self::assertInstanceOf(AuditToken::class, $context->token);
+        self::assertNotInstanceOf(AuditImpersonationToken::class, $context->token);
+        self::assertSame($user, $context->token->getUser());
+    }
+
+    public function testFromEntityWithImpersonationBuildsAnImpersonationToken(): void
+    {
+        $user = new FakeUser('alice');
+        $admin = new FakeUser('admin', ['ROLE_ADMIN']);
+        $entity = ConcreteAuditEntity::create(
+            1,
+            'App\\Action',
+            AuditSource::UI,
+            new \DateTimeImmutable(),
+            user: $user,
+            impersonatedBy: $admin,
+        );
+
+        $context = Context::fromEntity($entity);
+
+        self::assertInstanceOf(AuditImpersonationToken::class, $context->token);
+        self::assertSame($user, $context->token->getUser());
+        self::assertSame($admin, $context->token->getOriginalToken()->getUser());
+    }
+
+    public function testTransNamespacesTheSource(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->once())
+            ->method('trans')
+            ->with('source.console', [], 'audit', null)
+            ->willReturn('Console Terminal');
+
+        self::assertSame('Console Terminal', Context::console()->trans($translator));
+    }
+}

--- a/tests/Unit/ValueObject/IpAddressTest.php
+++ b/tests/Unit/ValueObject/IpAddressTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace WeDevelop\Audit\Tests\Unit\ValueObject;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use WeDevelop\Audit\Enum\AuditSource;
+use WeDevelop\Audit\Tests\Fixtures\Audit\ConcreteAuditEntity;
+use WeDevelop\Audit\ValueObject\IpAddress;
+
+final class IpAddressTest extends TestCase
+{
+    #[DataProvider('validAddresses')]
+    public function testFromRequestAcceptsValidAddresses(string $address): void
+    {
+        $request = Request::create('/', server: ['REMOTE_ADDR' => $address]);
+
+        $ip = IpAddress::fromRequest($request);
+
+        self::assertNotNull($ip);
+        self::assertSame($address, $ip->address);
+        self::assertSame($address, (string) $ip);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function validAddresses(): iterable
+    {
+        yield 'ipv4' => ['192.168.1.10'];
+        yield 'ipv6' => ['::1'];
+    }
+
+    public function testFromRequestReturnsNullWhenNoClientIp(): void
+    {
+        self::assertNull(IpAddress::fromRequest(new Request()));
+    }
+
+    public function testFromRequestRejectsInvalidAddress(): void
+    {
+        $request = Request::create('/', server: ['REMOTE_ADDR' => 'not-an-ip-address']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        IpAddress::fromRequest($request);
+    }
+
+    #[DataProvider('entityAddresses')]
+    public function testFromEntityReadsTheStoredAddress(?string $expected, ?string $stored): void
+    {
+        $entity = ConcreteAuditEntity::create(1, 'App\\Action', AuditSource::UI, new \DateTimeImmutable(), ipAddress: $stored);
+
+        $ip = IpAddress::fromEntity($entity);
+
+        self::assertSame($expected, null === $ip ? null : (string) $ip);
+    }
+
+    /** @return iterable<string, array{?string, ?string}> */
+    public static function entityAddresses(): iterable
+    {
+        yield 'address present' => ['10.0.0.1', '10.0.0.1'];
+        yield 'address missing' => [null, null];
+    }
+}

--- a/tools/coverage-gate.php
+++ b/tools/coverage-gate.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+/**
+ * Fails when line coverage from a Clover report drops below a threshold.
+ *
+ * PHPUnit has no built-in minimum-coverage gate, so the CI pipeline (and the
+ * `composer coverage` script) parse the Clover report here instead of pulling in
+ * an extra dependency.
+ *
+ * Usage: php tools/coverage-gate.php [clover-path] [threshold-percentage]
+ */
+
+$cloverPath = $argv[1] ?? 'coverage.xml';
+$threshold = (float) ($argv[2] ?? 95);
+
+if (!is_file($cloverPath)) {
+    fwrite(\STDERR, sprintf("Coverage report not found: %s\n", $cloverPath));
+    exit(1);
+}
+
+$xml = @simplexml_load_file($cloverPath);
+if (false === $xml || !isset($xml->project->metrics)) {
+    fwrite(\STDERR, sprintf("Could not parse Clover project metrics from: %s\n", $cloverPath));
+    exit(1);
+}
+
+// Clover's "statements"/"coveredstatements" on the project-level metrics element
+// is the line-coverage basis (each executable line is one statement).
+$metrics = $xml->project->metrics;
+$statements = (int) $metrics['statements'];
+$covered = (int) $metrics['coveredstatements'];
+
+if (0 === $statements) {
+    fwrite(\STDERR, "No statements found in coverage report.\n");
+    exit(1);
+}
+
+$percentage = $covered / $statements * 100;
+
+printf(
+    "Line coverage: %.2f%% (%d/%d statements); threshold %.2f%%\n",
+    $percentage,
+    $covered,
+    $statements,
+    $threshold,
+);
+
+if ($percentage < $threshold) {
+    fwrite(\STDERR, sprintf("FAIL: coverage %.2f%% is below threshold %.2f%%\n", $percentage, $threshold));
+    exit(1);
+}
+
+echo "PASS\n";
+exit(0);


### PR DESCRIPTION
## What

Adds an automated test suite (PHPUnit 11) and the GitHub Actions automation to run it, with a coverage gate. The library previously had no tests or test framework.

## Highlights

- **PHPUnit 11** (pinned to 11 for the PHP 8.2 floor); `phpunit.xml.dist` with separate **Unit** and **Integration** suites, coverage scoped to `src/`.
- **Unit tests** cover the pure-logic / mocked paths: `SubjectHelper` identifier extraction, `Context` factories + token construction, `IpAddress`, the audit log/entity base classes, `Presenter` pagination, value objects, tokens, `TranslationHelper`, and exceptions. Repetitive cases use data providers.
- **Integration tests** boot a real Doctrine ORM `EntityManager` on in-memory SQLite to exercise genuine metadata, identifier extraction, proxy unwinding, `Context::refDb` reference-swapping (managed / detached / impersonation), and `Presenter` ordering + pagination + reconstruction. The bootstrap is one cross-version code path (works on ORM 2.x and 3.x).
- **CI**: new `tests.yaml` runs the suite across a PHP 8.2/8.3/8.4 x lowest/highest matrix, plus a coverage job enforcing a **95% line-coverage gate** (dependency-free `tools/coverage-gate.php`). A `php-cs-fixer` dry-run job is added to `static-analysis.yaml`, pinned to PHP 8.2.

## Coverage

~99.5% line coverage. The single intentionally-uncovered line is the MongoDB ODM branch in `Context::refDb` — **ODM testing is deferred** (no `ext-mongodb` / Mongo service in CI; installs use `--ignore-platform-req=ext-mongodb`). `doctrine/mongodb-odm` stays in `require-dev` because PHPStan needs it.

## Notes

- New dev deps: `phpunit/phpunit`, `symfony/cache` (ORM metadata cache for the test bootstrap).
- A follow-up branch adds PHP 8.5 support (drops now-deprecated `setAccessible()` calls + 8.5 in the matrix); it will be opened as a separate PR once this lands.