### PR TITLE
Support and test PHP 8.5

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -18,6 +18,7 @@ jobs:
                     - '8.2'
                     - '8.3'
                     - '8.4'
+                    - '8.5'
         steps:
             - uses: 'actions/checkout@v4'
             - uses: 'shivammathur/setup-php@v2'
@@ -33,6 +34,7 @@ jobs:
                     - '8.2'
                     - '8.3'
                     - '8.4'
+                    - '8.5'
                 dependency-versions:
                     - 'lowest'
                     - 'highest'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,7 @@ jobs:
                     - '8.2'
                     - '8.3'
                     - '8.4'
+                    - '8.5'
                 dependency-versions:
                     - 'lowest'
                     - 'highest'

--- a/src/Util/SubjectHelper.php
+++ b/src/Util/SubjectHelper.php
@@ -115,7 +115,6 @@ class SubjectHelper
         if (1 === count($idProperties)) {
             $property = $idProperties[array_key_first($idProperties)];
             if ($property->isInitialized($subject)) {
-                $property->setAccessible(true);
                 return $property->getValue($subject);
             }
         } elseif (1 < count($idProperties)) {
@@ -126,10 +125,7 @@ class SubjectHelper
                 ksort($idProperties);
                 return array_combine(
                     array_map(static fn (\ReflectionProperty $property): string => $property->getName(), $idProperties),
-                    array_map(static function (\ReflectionProperty $property) use ($subject): mixed {
-                        $property->setAccessible(true);
-                        return $property->getValue($subject);
-                    }, $idProperties),
+                    array_map(static fn (\ReflectionProperty $property): mixed => $property->getValue($subject), $idProperties),
                 );
             }
         }
@@ -142,7 +138,6 @@ class SubjectHelper
         if ($reflection->hasProperty('id')) {
             $property = $reflection->getProperty('id');
             if ($property->isInitialized($subject)) {
-                $property->setAccessible(true);
                 return $property->getValue($subject);
             }
         }
@@ -157,7 +152,6 @@ class SubjectHelper
             if ($method->getNumberOfRequiredParameters() > 0) {
                 return null;
             }
-            $method->setAccessible(true);
             return $method->invoke($subject);
         }
         return null;


### PR DESCRIPTION
## What

Follow-up to #5: makes the library clean on PHP 8.5 and adds 8.5 to CI.

## Changes

- **Drop no-op `setAccessible()` calls in `SubjectHelper`.** `ReflectionProperty::setAccessible()` / `ReflectionMethod::setAccessible()` have been no-ops since PHP 8.1 (reflection always accesses private members) and are **deprecated as of PHP 8.5**. The library requires PHP >=8.2, so removing them is behaviour-preserving — and it clears the deprecation warnings plus the PHPStan `method.deprecated` errors that surface on 8.5. The now-single-statement composite-id closure becomes an arrow function, matching its sibling.
- **Add PHP 8.5 to the CI matrices** (syntax-linting, phpstan, tests). The integration bootstrap already enables ORM native lazy objects on PHP 8.4+, so the SQLite integration tests run on 8.5 too.

## Verified locally on PHP 8.5

- Full suite green — **0 deprecations** (was 4 before the `setAccessible` removal)
- PHPStan clean on `src`
- php-cs-fixer clean

No production behaviour change beyond removing dead no-op calls.