### PR TITLE
Upload test artifacts in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,3 +61,10 @@ jobs:
                   composer-options: '--ignore-platform-req=ext-mongodb'
             - run: './vendor/bin/phpunit --coverage-clover coverage.xml'
             - run: 'php tools/coverage-gate.php coverage.xml 95'
+            - if: always()
+              uses: 'actions/upload-artifact@v4'
+              with:
+                  # always() so the report is available even when the gate
+                  # fails the job, which is when inspecting coverage matters.
+                  name: 'coverage-clover'
+                  path: 'coverage.xml'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,15 @@ jobs:
                   # MongoDB/ODM is out of scope; the suite never instantiates Mongo
                   # objects, so the test pipeline must not depend on ext-mongodb.
                   composer-options: '--ignore-platform-req=ext-mongodb'
-            - run: './vendor/bin/phpunit'
+            - run: './vendor/bin/phpunit --log-junit junit.xml'
+            - if: always()
+              uses: 'actions/upload-artifact@v4'
+              with:
+                  # Matrix jobs share a run, so artifact names must be unique
+                  # (upload-artifact@v4 rejects duplicates); always() keeps the
+                  # results from failing combinations, which are the useful ones.
+                  name: 'junit-php${{ matrix.php }}-${{ matrix.dependency-versions }}'
+                  path: 'junit.xml'
 
     coverage:
         runs-on: 'ubuntu-24.04'


### PR DESCRIPTION
The Tests workflow ran PHPUnit but kept nothing afterwards: the matrix
discarded its results and the coverage job generated `coverage.xml` only to
feed the 95% gate before throwing it away. This adds downloadable artifacts
without changing what passes or fails the build.

Two separate commits:

1. **JUnit test results** — `phpunit --log-junit junit.xml`, uploaded from each
   matrix combination. Artifact names embed the PHP version and dependency tier
   because `upload-artifact@v4` rejects duplicate names within a run.
2. **Clover coverage report** — uploads the existing `coverage.xml` from the
   coverage job (Clover XML only; no HTML report).

Both uploads use `always()` so artifacts survive failed runs — the failing
combinations and a sub-95% coverage report are exactly what you'd want to pull
down and inspect.

No gating behaviour changes; these are developer-convenience artifacts.