### PR TITLE
Strip dev files from the Packagist dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Strip development-only files from the Composer "dist" archive.
+#
+# export-ignore applies to `git archive`, which is how Packagist builds the
+# dist package Composer downloads by default for tagged releases. These files
+# are not needed to run the library and only add noise to a consumer's vendor/
+# directory. Note: this has no effect on --prefer-source installs, and only
+# takes effect for tags created after this file is committed.
+#
+# Shipped: src/, composer.json, LICENSE.md, README.md
+
+/.github                export-ignore
+/docs                   export-ignore
+/tests                  export-ignore
+/tools                  export-ignore
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/.php-cs-fixer.dist.php  export-ignore
+/phpstan.dist.neon      export-ignore
+/phpunit.xml.dist       export-ignore
+/CODE_OF_CONDUCT.md     export-ignore


### PR DESCRIPTION
## Summary

Adds a `.gitattributes` file that uses `export-ignore` to strip development-only files from the Composer **dist** archive (the zip Packagist builds via `git archive` and Composer downloads by default for tagged releases).

After this change the published package ships only the runtime essentials:

- `composer.json`
- `LICENSE.md`
- `README.md`
- everything under `src/`

Excluded from the archive: `.github/`, `docs/`, `tests/`, `tools/`, `.gitattributes`, `.gitignore`, `.php-cs-fixer.dist.php`, `phpstan.dist.neon`, `phpunit.xml.dist`, `CODE_OF_CONDUCT.md`.

## Notes / caveats

- `export-ignore` only affects **dist** installs (Composer's default for tagged releases); it has no effect on `--prefer-source` installs.
- It only takes effect for tags created **after** this file is committed — already-published releases stay full-sized, so a new tag is needed.
- `LICENSE.md` and `README.md` are kept intentionally (license retention; README is small and useful when browsing `vendor/`).

## Verification

Confirmed with the real archive output:

\`\`\`
git archive --worktree-attributes --format=tar HEAD | tar -t
\`\`\`

Result contained only \`composer.json\`, \`LICENSE.md\`, \`README.md\`, and \`src/\`. (Note: \`git check-attr\` reports leaf paths under an excluded directory as "unspecified" because \`git archive\` skips whole subtrees without descending — the archive listing is the ground truth.)